### PR TITLE
Update README: local setup instructions and pipeline documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,6 +281,9 @@ functional-tests/build/*
 !.s2i/*
 1Get Latest.bat
 
-#MacOS stuff
+# MacOS stuff
 .DS_Store
 node_modules/
+
+# Database credentials
+app/Server/src/SERVERAPI/secrets.json

--- a/Readme.md
+++ b/Readme.md
@@ -1,14 +1,6 @@
-BC Ministry of Agriculture Nutrition Management Program
------------------
+# BC Ministry of Agriculture Nutrition Management Program
 
-Product Owner
---------
-Jeff Nimmo, Jeffrey.Nimmo@gov.bc.ca
-David Poon (alternate), David.Poon@gov.bc.ca
-
-
-Contribution
-------------
+## Contribution
 
 Please report any [issues](https://github.com/bcgov/agri-nmp/issues).
 
@@ -18,20 +10,19 @@ If you would like to contribute, please see our [contributing](CONTRIBUTING.md) 
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
-Development
------------
+## Development
+
 This project uses .NET Core version 3.1.
 
 You will need to install Visual Studio 2017 Preview 3 in order to effectively develop the application from a Windows PC.
 
 Note that .NET Core is cross platform, so you can also use a Mac or Linux computer equipped with the appropriate build tools.  
 
-Updates to code values without developer assistance
----------------------------------------------
+## Updates to code values without developer assistance
+
 This project allows non-technical users (i.e. Product Owners) with business domain knowledge, to revise and update static code table values, message text, etc.  See the [instructions](app/Server/src/SERVERAPI/Data/README.md) for details.
 
-Static Code Analysis (obsolete)
---------------------
+## Static Code Analysis (obsolete)
 
 Steps to conduct static code analysis:
 1) Install the Visual Studio 2017 Community Edition plus standalone build tools, such that you are able to compile the source for the application.
@@ -62,42 +53,45 @@ RedHat requires authentication to the image repository where the Dotnet images a
 
 8) In a command line with an active connection to OpenShift, and the current project set to the Tools project, run the following commands:
 
-`oc secrets link default <SECRETNAME> --for=pull`  
-`oc secrets add serviceaccount/builder secrets/<SECRETNAME>`
+    `oc secrets link default <SECRETNAME> --for=pull`  
+    `oc secrets add serviceaccount/builder secrets/<SECRETNAME>`
 
-Where `<SECRETNAME>` is the name you specified in step 7 when you imported the secret.
+    Where `<SECRETNAME>` is the name you specified in step 7 when you imported the secret.
 
 9) You can now import images from the Redhat repository.  For example:
 
-`oc import-image dotnet/dotnet-31-rhel7 --from=registry.redhat.io/dotnet/dotnet-31-rhel7 --confirm` 
+    `oc import-image dotnet/dotnet-31-rhel7 --from=registry.redhat.io/dotnet/dotnet-31-rhel7 --confirm` 
 
 10) Adjust your builds to use this imported image
 
-Note: For the Agri project, the pull secret is in the agri-nmp-tools namespace. It can't be shared with any other namespace. This is why you will see redis image stream being created in the agri-nmp-tools namespace and then this namespace being referenced in the deployment scripts which will run in other namespaces.
+*Note:* For the Agri project, the pull secret is in the agri-nmp-tools namespace. It can't be shared with any other namespace. This is why you will see redis image stream being created in the agri-nmp-tools namespace and then this namespace being referenced in the deployment scripts which will run in other namespaces.
 
 
-# REDIS Code - currently commented out
+# REDIS Code (currently commented out)
+
 As of Release 3 Redis containers were added, but due to some technical issues the application couldn't properly use them for session data. At this moment the code for Redis has been commented out in the application and in the pipelines. Product Owners agreed to run the app as a single container for now.
 
 # NMP application pod - Single Container
+
 Originally this application was running multiple containers and one of the loadbalancing change to the infrastructure broke this app. It had to do with the stickyness of sessions. As a best practice, application shouldn't rely on loadbalancer to provide sticky session function, rather it should manage its state externally. For this reason Redis was setup, but due to some outstanding issues, this was put on hold and currently the app is running as a single container.
 
-Will need to put this in the NMP pod, to resurrect Redis.
-                  // {
-                  //   "name": "REDIS_PASSWORD",
-                  //   "valueFrom": {
-                  //     "secretKeyRef": {
-                  //       "name": "${NAME}-redis-credentials${SUFFIX}",
-                  //       "key": "password"
-                  //     }
-                  //   }
-                  // },
+Will need to put this in the NMP pod, to resurrect Redis:
+```json
+{
+  "name": "REDIS_PASSWORD",
+  "valueFrom": {
+    "secretKeyRef": {
+      "name": "${NAME}-redis-credentials${SUFFIX}",
+      "key": "password"
+    }
+  }
+}
+```
 
 # Postgres - Single Container
-Due to non-critical nature of this appliction, Postgres currently runs as a single container. In the future, it can made HA using Patroni (used by other projects in BC Gov. Openshift platform).
+Due to the non-critical nature of this application, Postgres currently runs as a single container. In the future, it can made HA using Patroni (used by other projects in BC Gov. Openshift platform).
 
-License
--------
+# License
 
     Copyright 2017 Province of British Columbia
 
@@ -112,8 +106,3 @@ License
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
-Maintenance
------------
-
-This repository is maintained by BC Ministry of Agriculture

--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,16 @@ By default, if the database is empty, NMP will auto-populate it with static valu
 
 To update the values in the local database, use `pg_dump` to grab data from PROD.
 
+## CI/CD pipeline
+
+As all three NMP projects share the same namespace on OpenShift, they share a similar deployment process.
+
+Image builds are automatically triggered via GitHub webooks, whenever there is a push or PR merge to the main branch. A Tekton pipeline then performs image promotion, auto-deploying the build to DEV. 
+
+Deploying to TEST and PROD are done by manually starting the `promote-test-nmp-web` and `promote-prod-nmp-web` pipelines respectively. This can be done in the OpenShift web conosle, under **Pipelines** > **Pipelines** in the tools namespace, and clicking "Start" for the respective pipeline.
+
+To rollback PROD to the previous build, run the `undo-last-promote-prod-nmp-web` pipeline.
+
 ## Updates to code values without developer assistance
 
 This project allows non-technical users (i.e. Product Owners) with business domain knowledge, to revise and update static code table values, message text, etc.  See the [instructions](app/Server/src/SERVERAPI/Data/README.md) for details.

--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,12 @@ Don't forget to shut down the database after quitting:
 brew services stop postgresql
 ```
 
+#### Soil values
+
+By default, if the database is empty, NMP will auto-populate it with static values.
+
+To update the values in the local database, use `pg_dump` to grab data from PROD.
+
 ## Updates to code values without developer assistance
 
 This project allows non-technical users (i.e. Product Owners) with business domain knowledge, to revise and update static code table values, message text, etc.  See the [instructions](app/Server/src/SERVERAPI/Data/README.md) for details.

--- a/Readme.md
+++ b/Readme.md
@@ -12,11 +12,38 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## Development
 
-This project uses .NET Core version 3.1.
+This project uses .NET Core version 3.1 and PostgreSQL.
 
-You will need to install Visual Studio 2017 Preview 3 in order to effectively develop the application from a Windows PC.
+You will need Visual Studio, which supports both Mac and Windows.
 
-Note that .NET Core is cross platform, so you can also use a Mac or Linux computer equipped with the appropriate build tools.  
+### Running NMP locally
+
+1. Download and install [Visual Studio](https://visualstudio.microsoft.com/) (not Visual Studio Code). When installing, make sure you also select .NET or ASP .NET when prompted (menu options may vary depending on OS).
+2. Install PostgreSQL and create the local database. NMP will auto-populate it with static values on its first run:
+    ```sh
+    brew install postgresql
+    brew services run postgresql
+    psql postgres
+    create user nmp with encrypted password 'nmp';
+    create database nmp owner nmp;
+    ```
+3. Clone the repository.
+4. Create a file called `secrets.json` in `src/SERVERAPI` containing the following:
+    ```json
+    {
+        "Agri:ConnectionString": "Server=localhost;Database=nmp;Username=nmp;Password=nmp"
+    }
+    ```
+3. Open `agri-nmp/app/server/Server.sln` in Visual Studio, and wait for NuGet to download all the dependencies.
+4. Run SERVERAPI from inside Visual Studio. On Visual Studio for Mac,  this is the "play" icon in the top-left corner.
+
+
+Once running, the application can be accessed at http://localhost:8080.
+
+Don't forget to shut down the database after quitting:
+```sh
+brew services stop postgresql
+```
 
 ## Updates to code values without developer assistance
 


### PR DESCRIPTION
The local setup process is documented in this PR. As that process involves creating a `.env` file, it has also been added to `.gitignore`.

Instructions on how to use the pipeline have also been included.

The existing formatting has also been cleaned up.