### PR TITLE
NMP Calculator Cannot Continue With Animals Bug Fix

### DIFF
--- a/app/Server/src/SERVERAPI/Controllers/FarmController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/FarmController.cs
@@ -299,22 +299,6 @@ namespace SERVERAPI.Controllers
                 }
             }
 
-            {
-                var farmData = _ud.FarmDetails();
-
-                if (HasAnimalSelectionChanged(fvm, farmData))
-                {
-                    // something changed. verify user has confirmed.
-                    if (!fvm.TypeChangeConfirmed)
-                    {
-                        ModelState.AddModelError("TypeChangeConfirmed", "Confirmation is required to proceed with this change");
-                        return View(fvm);
-                    }
-                }
-            }
-
-
-
             if (ModelState.IsValid)
             {
                 fvm.HasSelectedFarmType = true;


### PR DESCRIPTION
Removed logic to check if a user has confirmed changes or not because it was just throwing an error and not allowing a user to confirm; therefore never proceeding to the next page.