### PR TITLE
[CHANGE][NPM-624] Dynamically update pruning details select options

### DIFF
--- a/app/Agri.Data/AgriConfigurationRepository.cs
+++ b/app/Agri.Data/AgriConfigurationRepository.cs
@@ -2087,7 +2087,7 @@ namespace Agri.Data
         }
         public List<SelectListItem> GetWhereWillPruningsGoDll()
         {
-            string[] values = { "N/A", "Removed from field", "Left in row", "Left between rows" };
+            string[] values = { "Removed from field", "Left in row", "Left between rows" };
             var result = values.ToList().Select((item, index) =>
                                     new SelectListItem() { Id = index, Value = item }).ToList();
             return result;

--- a/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
@@ -406,6 +406,9 @@
 
 <script>
     $(document).ready(function () {
+        //hideNAPruningsSelectOption();
+    });
+    $(document).ready(function () {
         $("body").on("change", "#ddlNumberOfPlantsPerAcre", function () {
             $('#buttonPressed').val("NumberOfPlantsPerAcreChange");
             $("#modForm").submit();
@@ -423,7 +426,9 @@
         RequireCalculate();
     });
 
-    $(document).on('change', '#ddlillPlantsBePruned', function () {
+    $(document).on('change', '#ddlillPlantsBePruned', function (event) {
+        const $this = $(this);
+        setPlantPruningSelectValues($this);
         RequireCalculate();
     });
 
@@ -441,10 +446,47 @@
         })
     });
 
-
     function RequireCalculate() {
         $("#ok_button").html('Calculate');
         $("#ok_button").css('background-color', '#1abbed');
         $("#btnText").val("Calculate");
+    }
+
+    function setPlantPruningSelectValues($this) {
+        const currentSelectValue = $this.val();
+        
+        if (currentSelectValue === "1") {
+            $("#ddlWhereWillPruningsGo").empty();
+            $("#ddlWhereWillPruningsGo").append(
+                $('<option>', {
+                    value: '0',
+                    text: 'N/A'
+                })
+            );
+        }
+
+        if (currentSelectValue === "0") {
+            $("#ddlWhereWillPruningsGo").empty();
+            $("#ddlWhereWillPruningsGo").append(
+                $('<option>', {
+                    value: '',
+                    text: 'select'
+                }));
+            $("#ddlWhereWillPruningsGo").append(
+                $('<option>', {
+                    value: '1',
+                    text: 'Removed from field'
+                }));
+            $("#ddlWhereWillPruningsGo").append(
+                $('<option>', {
+                    value: '2',
+                    text: 'Left in row"'
+                }));
+            $("#ddlWhereWillPruningsGo").append(
+                $('<option>', {
+                    value: '3',
+                    text: 'Left between rows'
+                }));
+        }
     }
 </script>

--- a/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
@@ -406,9 +406,6 @@
 
 <script>
     $(document).ready(function () {
-        //hideNAPruningsSelectOption();
-    });
-    $(document).ready(function () {
         $("body").on("change", "#ddlNumberOfPlantsPerAcre", function () {
             $('#buttonPressed').val("NumberOfPlantsPerAcreChange");
             $("#modForm").submit();


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Using jQuery to update the select options for "Where will prunings go?" select element. When the "Will plants be pruned?" is set to "No". 
- When set to "Yes" we reset the select options to: "Removed from field", "Left in row", "Left between rows".
- Removing "N/A" as a default option on page load

Page load:
![Screenshot 2024-03-05 at 8 36 48 AM](https://github.com/bcgov/agri-nmp/assets/20193291/dacebaa4-b594-420c-ae52-3dbf5215a034)

Yes:
![Screenshot 2024-03-05 at 8 36 40 AM](https://github.com/bcgov/agri-nmp/assets/20193291/963860f0-81cb-4aae-9b8a-f8b112c27cf9)

No:
![Screenshot 2024-03-05 at 8 36 33 AM](https://github.com/bcgov/agri-nmp/assets/20193291/ebc18ff8-8981-4b92-8275-f938f5cf624a)

