### PR TITLE
[CHANGE][NMP-626] adjusted tooltip icon to the right

### DIFF
--- a/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
@@ -146,7 +146,7 @@
                         <div class="form-group col-sm-4">
                             <label for="ddlWillSawdustBeApplied" style="margin-bottom:auto">
                                 <span>Is sawdust or wood mulch applied within the 6 months prior to the growing season?</span>
-                                <a href="#" data-toggle="tooltip" title="@Model.sawdustAppliedMessage" id="toolTipExplainSawdustApplied" style="position:absolute;left:91%;top:0%;">
+                                <a href="#" data-toggle="tooltip" title="@Model.sawdustAppliedMessage" id="toolTipExplainSawdustApplied" style="position:absolute;left:94%;top:0%;">
                                     <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Test" style="font-size:20px; padding-top:5px"></span>
                                 </a>
                             </label>


### PR DESCRIPTION
## Pull Request Standards
- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Moved the sawdust tooltip slightly to the right to deal with overlapping text on some browsers