### PR TITLE
[CHANGE][NMP-625] Update Crop Details form layout for sawdust question.

### DIFF
--- a/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
@@ -128,7 +128,7 @@
                     <div style="clear:both"></div>
                     <div class="row" style="margin-bottom: 1.5em;">
                         <div class="form-group col-sm-3">
-                            <br/>
+                            <br />
                             <label for="ddlillPlantsBePruned">Will plants be pruned?</label>
                             <select class="form-control" asp-for="selWillPlantsBePruned" asp-items="@(new SelectList(Model.willPlantsBePruned, "Id", "Value"))" id="ddlillPlantsBePruned">
                                 <option>select</option>
@@ -143,7 +143,9 @@
                             </select>
                             <span asp-validation-for="selWhereWillPruningsGo" class="text-danger"></span>
                         </div>
-                        <div class="form-group col-sm-10">
+                    </div>
+                    <div class="row" style="margin-bottom: 1.5em;">
+                        <div class="form-group col-sm-8">
                             <label for="ddlWillSawdustBeApplied">
                                 <span>Is sawdust or wood mulch applied within the 6 months prior to the growing season?</span>
                                 <a href="#" data-toggle="tooltip" title="@Model.sawdustAppliedMessage" id="toolTipExplainSawdustApplied">
@@ -151,7 +153,7 @@
                                 </a>
                             </label>
 
-                            <select class="form-control" asp-for="selWillSawdustBeApplied" asp-items="@(new SelectList(Model.willSawdustBeApplied, "Id", "Value"))" id="ddlWillSawdustBeApplied">
+                            <select class="form-control" style="width: 200px" asp-for="selWillSawdustBeApplied" asp-items="@(new SelectList(Model.willSawdustBeApplied, "Id", "Value"))" id="ddlWillSawdustBeApplied">
                                 <option>select</option>
                             </select>
                             <span asp-validation-for="selWillSawdustBeApplied" class="text-danger"></span>

--- a/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Crops/CropDetails.cshtml
@@ -143,10 +143,10 @@
                             </select>
                             <span asp-validation-for="selWhereWillPruningsGo" class="text-danger"></span>
                         </div>
-                        <div class="form-group col-sm-4">
-                            <label for="ddlWillSawdustBeApplied" style="margin-bottom:auto">
+                        <div class="form-group col-sm-10">
+                            <label for="ddlWillSawdustBeApplied">
                                 <span>Is sawdust or wood mulch applied within the 6 months prior to the growing season?</span>
-                                <a href="#" data-toggle="tooltip" title="@Model.sawdustAppliedMessage" id="toolTipExplainSawdustApplied" style="position:absolute;left:94%;top:0%;">
+                                <a href="#" data-toggle="tooltip" title="@Model.sawdustAppliedMessage" id="toolTipExplainSawdustApplied">
                                     <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Test" style="font-size:20px; padding-top:5px"></span>
                                 </a>
                             </label>


### PR DESCRIPTION
…ss browsers breaking tooltip layout.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Bump sawdust question onto it's own row. So that we don't need to position the tooltip relatively. The relative position is what is causing the issue due to no CSS reset and Bootstraps' Normalize not normalizing some elements of HTML forms across browsers.

![Screenshot 2024-03-22 at 8 40 50 AM](https://github.com/bcgov/agri-nmp/assets/20193291/f9ea7df5-8b70-4bf9-ba95-9be48af20f81)

![Screenshot 2024-03-22 at 8 43 00 AM](https://github.com/bcgov/agri-nmp/assets/20193291/541d65e3-66a4-4e88-ae51-183b3dd60c33)
