### PR TITLE
[NMP-647] [TASK] Removed berries flag

### DIFF
--- a/app/Agri.Models/Settings/AppSettings.cs
+++ b/app/Agri.Models/Settings/AppSettings.cs
@@ -8,7 +8,6 @@
         public bool RefreshDatabase { get; set; }
         public bool LoadSeedData { get; set; }
         public int ExpectedSeedDataVersion { get; set; }
-        public bool FLAG_BERRIES_WORKFLOW { get; set; }
         public bool RELOAD_JOURNEYS { get; set; }
         public bool RELOAD_USER_PROMPTS { get; set; }
         

--- a/app/Server/src/SERVERAPI/Controllers/FarmController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/FarmController.cs
@@ -96,7 +96,7 @@ namespace SERVERAPI.Controllers
                 fvm.ShowAnimals = false;
             }
 
-            fvm.ShowCropTypes = fvm.HasHorticulturalCrops && !fvm.HasAnimals && _appSettings.Value.FLAG_BERRIES_WORKFLOW;
+            fvm.ShowCropTypes = fvm.HasHorticulturalCrops && !fvm.HasAnimals;
             fvm.HasBerries = farmData.HasBerries;
 
             return View(fvm);
@@ -186,7 +186,7 @@ namespace SERVERAPI.Controllers
                 else
                 {
                     fvm.ShowAnimals = false;
-                    fvm.ShowCropTypes = fvm.HasHorticulturalCrops && _appSettings.Value.FLAG_BERRIES_WORKFLOW;
+                    fvm.ShowCropTypes = fvm.HasHorticulturalCrops;
                    
                 }
 
@@ -251,7 +251,7 @@ namespace SERVERAPI.Controllers
                   
                     if (fvm.HasHorticulturalCrops)
                     {
-                        fvm.ShowCropTypes = _appSettings.Value.FLAG_BERRIES_WORKFLOW && !fvm.ShowAnimals;
+                        fvm.ShowCropTypes = !fvm.ShowAnimals;
                     }
                     else
                     {
@@ -268,8 +268,8 @@ namespace SERVERAPI.Controllers
                 ModelState.Clear();
                 fvm.ButtonPressed = "";
                 var farmData = _ud.FarmDetails();
-                farmData.HasBerries = fvm.HasBerries && _appSettings.Value.FLAG_BERRIES_WORKFLOW;
-                fvm.ShowCropTypes = _appSettings.Value.FLAG_BERRIES_WORKFLOW;
+                farmData.HasBerries = fvm.HasBerries;
+                fvm.ShowCropTypes = true;
                 var fields = _ud.GetFields();
                 if (fvm.HasBerries)
                 {

--- a/app/Server/src/SERVERAPI/SERVERAPI.csproj
+++ b/app/Server/src/SERVERAPI/SERVERAPI.csproj
@@ -110,6 +110,11 @@
     <Content Update="Views\Shared\Components\ManureNutrientAnalysis\Default.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
+    <Content Update="Properties\launchSettings.json">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TypeScriptTarget>ES5</TypeScriptTarget>

--- a/app/Server/src/SERVERAPI/appsettings.json
+++ b/app/Server/src/SERVERAPI/appsettings.json
@@ -6,7 +6,6 @@
     "RefreshDatabase": false,
     "LoadSeedData": false,
     "ExpectedSeedDataVersion": 5,
-    "FLAG_BERRIES_WORKFLOW": false,
     "RELOAD_JOURNEYS": false,
     "RELOAD_USER_PROMPTS": false
   },


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):
- Removed the "FLAG_BERRIES_WORKFLOW" flag from AppSettings.cs, as well as other relevant files, to ensure that the berries option is always set to true.
- Tested berries workflow locally.
