### PR TITLE
Fix[NMP-703]: UI Fertigation Units

### DIFF
--- a/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
@@ -390,7 +390,7 @@ namespace SERVERAPI.Controllers
             fgvm.totPIcon = "";
             fgvm.totKIcon = "";
 
-            fgvm.fertigationTime = 0.0M;
+            fgvm.fertigationTime = 0M;
             fgvm.totProductVolPerFert = 0.0M;
             fgvm.totProductVolPerSeason = 0.0M;
 
@@ -797,11 +797,11 @@ namespace SERVERAPI.Controllers
                         decimal convertedProductRate = Convert.ToDecimal(fgvm.productRate) * _fU.ConversionToImperialGallonsPerAcre;
 
                         //Total Product Volume per fertigation
-                        fgvm.totProductVolPerFert =  Math.Round((field.Area * convertedProductRate), 2); // convert to int/string? Error messages?
+                        fgvm.totProductVolPerFert =  Math.Round((field.Area * convertedProductRate), 1); // convert to int/string? Error messages?
 
                         // Total product volume per growing season calc
                         // Product Rate x Fertigation area x fert per season 
-                        fgvm.totProductVolPerSeason = Math.Round((field.Area * convertedProductRate * fgvm.eventsPerSeason), 2); // convert to int/string? Error messages?
+                        fgvm.totProductVolPerSeason = Math.Round((field.Area * convertedProductRate * fgvm.eventsPerSeason), 1); // convert to int/string? Error messages?
 
                         decimal injectionRateConversion = 0;
                         switch (fgvm.selInjectionRateUnitOption)
@@ -826,7 +826,7 @@ namespace SERVERAPI.Controllers
 
                         //Fertigation time 
                         decimal fertTimeVal = Convert.ToDecimal(fgvm.totProductVolPerFert) / (Convert.ToDecimal(fgvm.injectionRate) / injectionRateConversion);
-                        fgvm.fertigationTime = Math.Round(fertTimeVal, 2); 
+                        fgvm.fertigationTime = Math.Round(fertTimeVal, 0); 
                         
                         //Applied nutrients per fertigation  
                         fgvm.calcN = Convert.ToInt32(fertilizerNutrients.fertilizer_N).ToString();
@@ -1017,10 +1017,10 @@ namespace SERVERAPI.Controllers
             fgvm.nutrientConcentrationP205 = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valP2o5) / 100 / tankVolume, 2));
 
             decimal injectionRate = Convert.ToDecimal(fgvm.injectionRate);
-            fgvm.fertigationTime = Math.Round(Convert.ToDecimal(fgvm.tankVolume) / injectionRate, 2);
+            fgvm.fertigationTime = Math.Round(Convert.ToDecimal(fgvm.tankVolume) / injectionRate, 0);
 
             if (amountToDissolve <= tankVolume * solInWater){
-                fgvm.dryAction = "Good";
+                fgvm.dryAction = "Soluble";
             }
             else{
                 fgvm.dryAction = "Reduce the amount to dissolve";

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -245,7 +245,7 @@
                 @if(Model.selTypOption == "1" || Model.selTypOption == "2"){
                     <div class="form-group col-sm-8" style="display:flex; align-items:center; margin:5px; height: 40px;">
                       <div>
-                          <label style="display:flex; align-items:center;">
+                          <label style="display:flex; align-items:center; padding-left: 50px;">
                               Time per Application
                           </label>
                           <div class="cell" style="text-wrap: pretty; text-align: center;">
@@ -291,8 +291,8 @@
                 <div class="form-group" style="display:flex; justify-content:space-between; width:90%">
                   <div class="form-group col-sm-8" style="margin:5px">
                     <div class="Table">
-                          <div class="Title" style="height: 45px;">
-                              <p>Applied Nutrients Per Fetigation (lb/ac)</p>
+                          <div class="Title">
+                              <p>Applied Nutrients Per Fertigation (lb/ac)</p>
                           </div>
                           <div class="Heading">
                               <div class="Cell">

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -23,7 +23,7 @@
                         <span asp-validation-for="selTypOption" class="text-danger"></span>
                     </div>
                     <div class="form-group col-sm-3" style="width:200px;">
-                        @if(Model.selTypOption == "4" || Model.selTypOption == "2"){ // if custom liquid fertigation 
+                        @if(Model.selTypOption == "4" || Model.selTypOption == "2"){ // if custom liquid fertigation
                             <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
                                 <label for="valN">N(%)</label>
                                 <div>
@@ -52,9 +52,9 @@
                             </select>
                             <span asp-validation-for="selFertOption" class="text-danger"></span>
                         }
-     
+
                     </div>
-                    @if(Model.selTypOption == "1" || Model.selTypOption == "2"){ 
+                    @if(Model.selTypOption == "1" || Model.selTypOption == "2"){
                     <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
                         <label for="rate">Tank Volume</label>
                         <div>
@@ -113,7 +113,7 @@
                             {
                                 <span style="color: #4BB543;">@Model.dryAction </span>
                                 <img src="~/images/good.svg" title="Soluble"/>
-                            
+
                             }
                             else if (Model.dryAction == "Reduce the amount to dissolve")
                             {
@@ -188,8 +188,8 @@
                     }
                 </div>
             </div>
-        
-            <div style="margin-top: 20px;"></div> 
+
+            <div style="margin-top: 20px;"></div>
 
             <div class="row">
                 <div class="form-group">
@@ -236,10 +236,10 @@
                 <button class="btn" type="button" data-dismiss="modal">Cancel</button>
             <button type="submit" class="btn btn-primary" id="calc_button" @( Model.btnText == "Calculate" ? Html.Raw(" style='background-color: #1abbed'") : Html.Raw(""))>Calculate</button>
             </div>
-            
+
 
                 <hr style="height:1px;border:none;color:blue;background-color:lightblue;padding:0; margin-top: 5px;" />
-              
+
               <div class="row">
                 <div class="form-group" style="display:flex; justify-content:space-between; width:90%">
                 @if(Model.selTypOption == "1" || Model.selTypOption == "2"){
@@ -257,7 +257,7 @@
                   <div class="form-group col-sm-8" style="margin:5px">
                       <div class="table">
                           <label id="productVolumeLabel" style="text-wrap: pretty; text-align: center; height: 40px;">
-                              Total Product Volume per Application (select a unit)
+                              Total Product Volume per Application (Select a unit)
                           </label>
                           <div class="cell" style="text-align:center">
                             @Model.totProductVolPerFert
@@ -457,17 +457,17 @@
 <script>
    $(document).ready(function () {
     $('#applDate').datepicker({
-        format: "dd-M-yyyy", 
+        format: "dd-M-yyyy",
         autoclose: true,
         todayHighlight: true,
         clearBtn: true,
         startView: 0,
-        minViewMode: 0, 
+        minViewMode: 0,
         endDate: '+10y',
-        defaultViewDate: new Date() 
+        defaultViewDate: new Date()
     }).on('changeDate', function(e) {
-       
-        $('#applDate').val(e.format('dd-M-yyyy'));  
+
+        $('#applDate').val(e.format('dd-M-yyyy'));
     });
 
     var existingDate = $('#applDate').val();
@@ -475,24 +475,21 @@
         var dateParts = existingDate.split('-');
         if (dateParts.length === 3) {
             var day = dateParts[0];
-            var month = new Date(Date.parse(dateParts[1] +" 1, 2024")).getMonth(); 
+            var month = new Date(Date.parse(dateParts[1] +" 1, 2024")).getMonth();
             var year = dateParts[2];
-            var date = new Date(year, month, day); 
+            var date = new Date(year, month, day);
             $('#applDate').datepicker('setDate', date);
         }
     }
 
-    //change unit label based on userUnit selection of Application rate units
-    $('#ddlProdRate').on('change', function () {
-        var userUnit = $(this).find("option:selected").text(); 
+    // Function to update unit labels
+    function updateUnits() {
+        var userUnit = $('#ddlProdRate').find("option:selected").text();
         $('#productVolumeLabel').text('Total Product Volume per Application (' + userUnit + ')');
         $('#productVolumeGrowingLabel').text('Total Product Volume Growing Season (' + userUnit + ')');
-    });
-    // On page load, initialize the label based on the selected unit
-    $(function () {
-        var initialUnit = $('#ddlProdRate option:selected').text();
-        $('#productVolumeLabel').text('Total Product Volume per Application (' + initialUnit + ')');
-        $('#productVolumeGrowingLabel').text('Total Product Volume for Growing Season (' + initialUnit + ')');
-    });
+    }
+
+    // On page load, initialize unit label
+    updateUnits();
 });
 </script>

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -106,13 +106,13 @@
                     <div class="form-group col-sm-4" style="display:flex; align-items: center;">
                       <div>
                           <label >
-                              Action
+                              Solubility Assessment
                           </label>
                           <div class="cell" style="text-align:center">
-                            @if (Model.dryAction == "Good")
+                            @if (Model.dryAction == "Soluble")
                             {
                                 <span style="color: #4BB543;">@Model.dryAction </span>
-                                <img src="~/images/good.svg" title="Good"/>
+                                <img src="~/images/good.svg" title="Soluble"/>
                             
                             }
                             else if (Model.dryAction == "Reduce the amount to dissolve")
@@ -241,22 +241,22 @@
                 <hr style="height:1px;border:none;color:blue;background-color:lightblue;padding:0; margin-top: 5px;" />
               
               <div class="row">
-                <div class="form-group">
+                <div class="form-group" style="display:flex; justify-content:space-between; width:90%">
                 @if(Model.selTypOption == "1" || Model.selTypOption == "2"){
-                    <div class="form-group col-sm-4" style="display:flex; align-items: center;">
+                    <div class="form-group col-sm-8" style="display:flex; align-items:center; margin:5px; height: 40px;">
                       <div>
-                          <label >
-                              Fertigation Time (Minutes)
+                          <label style="display:flex; align-items:center;">
+                              Time per Application
                           </label>
-                          <div class="cell" style="text-align:center">
-                            @Model.fertigationTime
+                          <div class="cell" style="text-wrap: pretty; text-align: center;">
+                            @Model.fertigationTime minutes
                           </div>
                       </div>
                   </div>
                 } else {
-                  <div class="form-group col-sm-4" style="display:flex; align-items: center;">
-                      <div>
-                          <label id="productVolumeLabel" style="text-wrap: pretty; text-align: center;">
+                  <div class="form-group col-sm-8" style="margin:5px">
+                      <div class="table">
+                          <label id="productVolumeLabel" style="text-wrap: pretty; text-align: center; height: 40px;">
                               Total Product Volume per Application (select a unit)
                           </label>
                           <div class="cell" style="text-align:center">
@@ -264,9 +264,9 @@
                           </div>
                       </div>
                   </div>
-                  <div class="form-group col-sm-4" style="display:flex; align-items: center;">
-                      <div>
-                          <label id="productVolumeGrowingLabel" style="text-wrap: pretty; text-align: center;">
+                  <div class="form-group col-sm-8" style="margin:5px">
+                      <div class="table">
+                          <label id="productVolumeGrowingLabel" style="text-wrap: pretty; text-align: center; height: 40px;">
                               Total Product Volume for Growing Season (select a unit)
                           </label>
                           <div class="cell" style="text-align:center">
@@ -274,13 +274,13 @@
                           </div>
                       </div>
                   </div>
-                  <div class="form-group col-sm-4" style="display:flex; align-items: center;">
-                      <div>
-                          <label >
+                  <div class="form-group col-sm-8" style="margin:5px">
+                      <div class="table">
+                          <label style="height: 40px; text-align:center">
                               Time per Application
                           </label>
                           <div class="cell" style="text-align:center">
-                            @Model.fertigationTime
+                            @Model.fertigationTime minutes
                           </div>
                       </div>
                   </div>
@@ -289,9 +289,9 @@
               </div>
               <div class="row">
                 <div class="form-group" style="display:flex; justify-content:space-between; width:90%">
-                  <div class="form-group col-sm-3" style="margin:5px">
+                  <div class="form-group col-sm-8" style="margin:5px">
                     <div class="Table">
-                          <div class="Title">
+                          <div class="Title" style="height: 45px;">
                               <p>Applied Nutrients Per Fetigation (lb/ac)</p>
                           </div>
                           <div class="Heading">
@@ -318,9 +318,9 @@
                           </div>
                       </div>
                   </div>
-                  <div class="form-group col-sm-3" style="margin:5px">
+                  <div class="form-group col-sm-8" style="margin:5px">
                       <div class="Table">
-                          <div class="Title">
+                          <div class="Title" style="height: 45px;">
                               <p>Total Applied Nutrients (lb/ac)</p>
                           </div>
                           <div class="Heading">
@@ -347,9 +347,9 @@
                           </div>
                       </div>
                   </div>
-                  <div class="form-group col-sm-3" style="margin:5px">
+                  <div class="form-group col-sm-8" style="margin:5px">
                       <div class="Table">
-                          <div class="Title">
+                          <div class="Title" style="height: 45px;">
                               <p>Still Required This Year (lbs/ac)</p>
                           </div>
                           <div class="Heading">

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -153,14 +153,14 @@
                       </div>
                       </div>
                     } else {
-                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
-                            <label for="rate">Product Rate</label>
+                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:120px">
+                            <label for="rate">Application Rate</label>
                             <div>
                                 <input class="form-control" asp-for="productRate" id="rate" type="text" />
                                 <span asp-validation-for="productRate" class="text-danger"></span>
                             </div>
                         </div>
-                        <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px">
+                        <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px;width:100px">
                             <div style="display:table; width:100%">
                                 <div style="display:table-row">
                                     <label for="ddlProdRate" style="text-align: center; display: block;">Units</label>
@@ -209,14 +209,14 @@
                         </div>
                     </div>
                     <div class="form-group col-sm-4">
-                        <label for="eventsPerSeason">Proposed Number of Fertigation Per Season</label>
+                        <label for="eventsPerSeason">Number of Fertigation Applications per Season</label>
                         <div>
                             <input class="form-control" id="eventsPerSeason" type="number" min="1" asp-for="eventsPerSeason" style="width:100px" />
                             <span asp-validation-for="eventsPerSeason" class="text-danger" value=1></span>
                         </div>
                     </div>
                     <div class="form-group col-sm-3">
-                        <label for="ddlMan">Fertigation Scheduling</label>
+                        <label for="ddlMan">Application Frequency</label>
                         <select class="form-control" id="ddlApplPeriod" style="width:100%" asp-for="selFertSchedOption" asp-items="@(new SelectList(Model.applPeriod,"Id","Value"))">
                             <option></option>
                         </select>
@@ -256,8 +256,8 @@
                 } else {
                   <div class="form-group col-sm-4" style="display:flex; align-items: center;">
                       <div>
-                          <label style="text-wrap: pretty; text-align: center;">
-                              Total Product Volume per Fertigation (Imp. gal)
+                          <label id="productVolumeLabel" style="text-wrap: pretty; text-align: center;">
+                              Total Product Volume per Application (select a unit)
                           </label>
                           <div class="cell" style="text-align:center">
                             @Model.totProductVolPerFert
@@ -266,8 +266,8 @@
                   </div>
                   <div class="form-group col-sm-4" style="display:flex; align-items: center;">
                       <div>
-                          <label style="text-wrap: pretty; text-align: center;">
-                              Total Product Volume for Growing Season (Imp. gal)
+                          <label id="productVolumeGrowingLabel" style="text-wrap: pretty; text-align: center;">
+                              Total Product Volume for Growing Season (select a unit)
                           </label>
                           <div class="cell" style="text-align:center">
                             @Model.totProductVolPerSeason
@@ -277,7 +277,7 @@
                   <div class="form-group col-sm-4" style="display:flex; align-items: center;">
                       <div>
                           <label >
-                              Fertigation Time (Minutes)
+                              Time per Application
                           </label>
                           <div class="cell" style="text-align:center">
                             @Model.fertigationTime
@@ -481,5 +481,18 @@
             $('#applDate').datepicker('setDate', date);
         }
     }
+
+    //change unit label based on userUnit selection of Application rate units
+    $('#ddlProdRate').on('change', function () {
+        var userUnit = $(this).find("option:selected").text(); 
+        $('#productVolumeLabel').text('Total Product Volume per Application (' + userUnit + ')');
+        $('#productVolumeGrowingLabel').text('Total Product Volume Growing Season (' + userUnit + ')');
+    });
+    // On page load, initialize the label based on the selected unit
+    $(function () {
+        var initialUnit = $('#ddlProdRate option:selected').text();
+        $('#productVolumeLabel').text('Total Product Volume per Application (' + initialUnit + ')');
+        $('#productVolumeGrowingLabel').text('Total Product Volume for Growing Season (' + initialUnit + ')');
+    });
 });
 </script>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):
- Change the headings for 'Fertigation Details - Add' page
- Match 'Total Product Volume per Fertigation' and 'Total Product Volume for Growing Season' to the unit the user selects for product rate
- Round Volumes to One decimal place, time to the nearest minute (no decimals)
- Headers for N, P2O5, and K2O need to be aligned and the icons in 'Still Required This Year' should go beside the number totals
- Change 'Action' header for both Dry Fertilizer and Dry Fertilizer (Custom) to 'Solubility Assessment'
- Change output text from 'Good' to 'Soluble' and keep the green checkmark

![Screenshot 2024-11-28 at 12 11 31 PM](https://github.com/user-attachments/assets/28faa914-f424-42ea-b009-cfc8489c58f5)

<img width="163" alt="Screenshot 2024-11-27 at 2 35 25 PM" src="https://github.com/user-attachments/assets/8d5665f0-3dad-4cc9-8f7c-e362b8e6ef31">