### PR TITLE
fix(frontend)[NMP-705]: UI Fixes to Fertigation Modal

### DIFF
--- a/app/Agri.Data/SeedData/UserPromptsData.json
+++ b/app/Agri.Data/SeedData/UserPromptsData.json
@@ -789,5 +789,33 @@
     "Text": "Sawdust and other materials with a high carbon to nitrogen ratio (C:N) will immobilize plant-available nitrogen in the soil. Selecting 'Yes' to this question will increase the amount of nitrogen that needs to be applied to ensure the crop receives enough nitrogen for optimal growth and yield.",
     "UserPromptPage": null,
     "UserJourney": null
+  },
+  {
+    "Id": 119,
+    "Name": "injectioninfomessage",
+    "Text": "Enter the rate in which your fertigation equipment applies fertilizer, not its overall output rate.",
+    "UserPromptPage": "Calculate",
+    "UserJourney": "Mixed"
+  },
+  {
+    "Id": 120,
+    "Name": "applicationinfomessage",
+    "Text": "The rate of fertilizer to be applied, not the overall output rate of your application system.",
+    "UserPromptPage": "Calculate",
+    "UserJourney": "Mixed"
+  },
+  {
+    "Id": 121,
+    "Name": "timeinfomessage",
+    "Text": "The amount of time required to apply fertilizer at the input fertilizer application rate, based on the injection rate entered above.",
+    "UserPromptPage": "Calculate",
+    "UserJourney": "Mixed"
+  },
+  {
+    "Id": 122,
+    "Name": "tankvolumeinfomessage",
+    "Text": "",
+    "UserPromptPage": "Calculate",
+    "UserJourney": "Mixed"
   }
 ]

--- a/app/Agri.Data/SeedData/UserPromptsData.json
+++ b/app/Agri.Data/SeedData/UserPromptsData.json
@@ -814,7 +814,7 @@
   {
     "Id": 122,
     "Name": "tankvolumeinfomessage",
-    "Text": "",
+    "Text": "Enter the volume of fertilizer mixture to be applied; do not enter the fertigation system's total output volume.",
     "UserPromptPage": "Calculate",
     "UserJourney": "Mixed"
   }

--- a/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
@@ -265,6 +265,10 @@ namespace SERVERAPI.Controllers
               id = id,
               isFertigation = true,
               groupID = groupID,
+              ExplainInjectionRate = _sd.GetUserPrompt("injectioninfomessage"),
+              ExplainApplicationRate = _sd.GetUserPrompt("applicationinfomessage"),
+              ExplainTime = _sd.GetUserPrompt("timeinfomessage"),
+              ExplainTankVolume = _sd.GetUserPrompt("tankvolumeinfomessage"),
             };
             if(id == null){
                 ModelState.AddModelError("start", "invalid");
@@ -293,7 +297,7 @@ namespace SERVERAPI.Controllers
                 fgvm.selSolubilityUnitOption = nf.solInWaterUnitId;
                 fgvm.eventsPerSeason = getNumberOfEvents(fgvm);
                 fgvm.selFertSchedOption = nf.applMethodId.ToString();
-                fgvm.injectionRate = nf.injectionRate.ToString("#.##"); 
+                fgvm.injectionRate = nf.injectionRate.ToString("#.##");
                 fgvm.selInjectionRateUnitOption = nf.injectionRateUnitId.ToString();
                 fgvm.tankVolume = nf.tankVolume.ToString("#.##");
                 fgvm.selTankVolumeUnitOption = nf.tankVolumeUnitId;

--- a/app/Server/src/SERVERAPI/ViewModels/FertigationDetailsViewModel.cs
+++ b/app/Server/src/SERVERAPI/ViewModels/FertigationDetailsViewModel.cs
@@ -141,5 +141,11 @@ namespace SERVERAPI.ViewModels
         // Miscellaneous
         public bool isFertigation { get; set; }
         public string groupID { get; set; }
+
+        //Tooltips
+        public string ExplainInjectionRate { get; set; }
+        public string ExplainApplicationRate { get; set; }
+        public string ExplainTime { get; set; }
+        public string ExplainTankVolume { get; set; }
     }
 }

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -22,23 +22,23 @@
                         </select>
                         <span asp-validation-for="selTypOption" class="text-danger"></span>
                     </div>
-                    <div class="form-group col-sm-3" style="margin-top: 8px;">
+                    <div class="form-group col-sm-3" style="margin-top: 8px; height: 57.56px;">
                         @if(Model.selTypOption == "4" || Model.selTypOption == "2"){ // if custom liquid fertigation 
-                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
                                 <label for="valN">N(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valN" id="valN" type="text" />
                                     <span asp-validation-for="valN" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
                                 <label for="valP2o5">P₂O₅(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valP2o5" id="valP2o5" type="text" />
                                     <span asp-validation-for="valP2o5" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
                                 <label for="valK2o">K₂O(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valK2o" id="valK2o" type="text" />

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -57,8 +57,8 @@
                     @if(Model.selTypOption == "1" || Model.selTypOption == "2"){ 
                     <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:120px;">
                         <label for="rate">Tank Volume</label>
-                            <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
-                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                            <a href="#" data-toggle="tooltip" title="@Model.ExplainTankVolume" id="toolTipExplainTankVolume">
+                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Tank Volume" style="font-size:20px;"></span>
                           </a>
                         <div>
                             <input class="form-control" asp-for="tankVolume" id="ddlTankVolume" type="text" />
@@ -471,33 +471,47 @@
 
 <script>
 $(document).ready(function () {
-  //Tooltips for injectionRate rate
-    $('#toolTipExplainInjectionRate').tooltip({
-        template: toolTipClickableInnerHtml,
-        html: true,
-        trigger: 'manual',
-    });
-    $('#toolTipExplainInjectionRate').click(function () {
-        triggerToolTip($('#toolTipExplainInjectionRate'));
-    });
-    //tooltip for Application rate
-    $('#toolTipExplainApplicationRate').tooltip({
-        template: toolTipClickableInnerHtml,
-        html: true,
-        trigger: 'manual',
-    });
-    $('#toolTipExplainApplicationRate').click(function () {
-        triggerToolTip($('#toolTipExplainApplicationRate'));
-    });
-    //tooltip for times per fertigation
-    $('#toolTipExplainTime').tooltip({
-        template: toolTipClickableInnerHtml,
-        html: true,
-        trigger: 'manual',
-    });
-    $('#toolTipExplainTime').click(function () {
-        triggerToolTip($('#toolTipExplainTime'));
-    });
+
+    function initializeToolTips() {
+      //Tooltips for injectionRate rate
+        $('#toolTipExplainInjectionRate').tooltip({
+            template: toolTipClickableInnerHtml,
+            html: true,
+            trigger: 'manual',
+        });
+        $('#toolTipExplainInjectionRate').click(function () {
+            triggerToolTip($('#toolTipExplainInjectionRate'));
+        });
+        //tooltip for Application rate
+        $('#toolTipExplainApplicationRate').tooltip({
+            template: toolTipClickableInnerHtml,
+            html: true,
+            trigger: 'manual',
+        });
+        $('#toolTipExplainApplicationRate').click(function () {
+            triggerToolTip($('#toolTipExplainApplicationRate'));
+        });
+        //tooltip for times per fertigation
+        $('#toolTipExplainTime').tooltip({
+            template: toolTipClickableInnerHtml,
+            html: true,
+            trigger: 'manual',
+        });
+        $('#toolTipExplainTime').click(function () {
+            triggerToolTip($('#toolTipExplainTime'));
+        });
+        //tooltip for tank volume
+        $('#toolTipExplainTankVolume').tooltip({
+            template: toolTipClickableInnerHtml,
+            html: true,
+            trigger: 'manual',
+        });
+        $('#toolTipExplainTankVolume').click(function () {
+            triggerToolTip($('#toolTipExplainTankVolume'));
+        });
+    }
+
+    initializeToolTips()
 
     $('#applDate').datepicker({
         format: "dd-M-yyyy",

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -15,30 +15,30 @@
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
                     <h4 class="title" style="margin-bottom: 15px;">Provide Product Details</h4>
-                    <div class="form-group col-sm-3" style="width:200px;">
+                    <div class="form-group col-sm-3" style="width:200px;     margin-top: 8px;">
                         <label for="ddlTyp">Fertilizer Type</label>
                         <select class="form-control" asp-for="selTypOption" asp-items="@(new SelectList(Model.typOptions,"Id","Value"))" id="ddlTyp">
                             <option value="">select</option>
                         </select>
                         <span asp-validation-for="selTypOption" class="text-danger"></span>
                     </div>
-                    <div class="form-group col-sm-3" style="width:200px;">
+                    <div class="form-group col-sm-3" style="margin-top: 8px;">
                         @if(Model.selTypOption == "4" || Model.selTypOption == "2"){ // if custom liquid fertigation 
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
                                 <label for="valN">N(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valN" id="valN" type="text" />
                                     <span asp-validation-for="valN" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
                                 <label for="valP2o5">P₂O₅(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valP2o5" id="valP2o5" type="text" />
                                     <span asp-validation-for="valP2o5" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin:0px; padding:0px; width:60px;">
                                 <label for="valK2o">K₂O(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valK2o" id="valK2o" type="text" />
@@ -55,15 +55,15 @@
      
                     </div>
                     @if(Model.selTypOption == "1" || Model.selTypOption == "2"){ 
-                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px; margin-top: 8px;">
                         <label for="rate">Tank Volume</label>
                         <div>
                             <input class="form-control" asp-for="tankVolume" id="ddlTankVolume" type="text" />
                             <span asp-validation-for="tankVolume" class="text-danger"></span>
                         </div>
                     </div>
-                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px">
-                        <div style="display:table; width:100%">
+                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; margin-top: 8px;">
+                        <div style="display:table; width:100%;">
                             <div style="display:table-row">
                                 <label for="ddlProdRate" style="text-align: center; display: block;">Units</label>
                                 <select class="form-control" asp-for="selTankVolumeUnitOption" asp-items="@(new SelectList(Model.tankVolumeUnitOptions,"Id","Value"))" id="ddlTankVolume"></select>
@@ -71,14 +71,14 @@
                             </div>
                         </div>
                     </div>
-                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px; margin-top: 8px;">
                         <label for="density">Solubility</label>
                         <div>
                             <input class="form-control" asp-for="solInWater" id="ddlSolInWater" type="text" />
                             <span asp-validation-for="solInWater" class="text-danger"></span>
                         </div>
                     </div>
-                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px; margin-top: 8px;">
                         <div style="display:table; width:100%">
                             <div style="display:table-row">
                                 <label for="ddlSolubilityUnits" style="text-align: center; display: block;">Units</label>
@@ -87,14 +87,14 @@
                             </div>
                         </div>
                     </div>
-                    <div class="form-group col-sm-4" style="margin-right:0px; padding-right:0px; width:140px">
+                    <div class="form-group col-sm-4" style="margin-right:0px; padding-right:0px; width:140px; margin-top: 8px;">
                         <label for="density">Amount to Dissolve</label>
                         <div>
                             <input class="form-control" asp-for="amountToDissolve" id="ddlAmountToDissolve" type="text"/>
                             <span asp-validation-for="amountToDissolve" class="text-danger"></span>
                         </div>
                     </div>
-                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px; margin-top: 8px;">
                         <div style="display:table; width:100%">
                             <div style="display:table-row">
                                 <label for="ddlDissolveUnits" style="text-align: center; display: block;">Units</label>
@@ -103,7 +103,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="form-group col-sm-4" style="display:flex; align-items: center;">
+                    <div class="form-group col-sm-4" style="display:flex; align-items: center; width: 100px; margin-top: 8px;">
                       <div>
                           <label >
                               Action
@@ -153,14 +153,17 @@
                       </div>
                       </div>
                     } else {
-                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
+                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:120px">
                             <label for="rate">Product Rate</label>
+                            <a href="#" data-toggle="tooltip" title="@Model.ExplainApplicationRate" id="toolTipExplainApplicationRate">
+                                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Application Rate" style="font-size:20px;"></span>
+                            </a>
                             <div>
                                 <input class="form-control" asp-for="productRate" id="rate" type="text" />
                                 <span asp-validation-for="productRate" class="text-danger"></span>
                             </div>
                         </div>
-                        <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px">
+                        <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; margin-top: 8px;">
                             <div style="display:table; width:100%">
                                 <div style="display:table-row">
                                     <label for="ddlProdRate" style="text-align: center; display: block;">Units</label>
@@ -169,14 +172,14 @@
                                 </div>
                             </div>
                         </div>
-                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px; margin-top: 8px;">
                         <label for="density">Density</label>
                         <div>
                             <input class="form-control" asp-for="density" id="density" type="text" />
                             <span asp-validation-for="density" class="text-danger"></span>
                         </div>
                     </div>
-                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-left:0px;padding-left:0px; width:100px; margin-top: 8px;">
                         <div style="display:table; width:100%">
                             <div style="display:table-row">
                                 <label for="ddlDensity" style="text-align: center; display: block;">Units</label>
@@ -194,8 +197,11 @@
             <div class="row">
                 <div class="form-group">
                     <h4 class="title" style="margin-bottom: 15px;">Provide Application Details</h4>
-                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px">
+                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:150px">
                         <label for="injectionRate">Injection Rate</label>
+                        <a href="#" data-toggle="tooltip" title="@Model.ExplainInjectionRate" id="toolTipExplainInjectionRate">
+                            <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Injection Rate" style="font-size:20px;"></span>
+                        </a>
                         <div>
                             <input class="form-control" asp-for="injectionRate" id="injectionRate" type="text" />
                             <span asp-validation-for="injectionRate" class="text-danger"></span>
@@ -203,20 +209,20 @@
                     </div>
                     <div class="form-group col-sm-2" style="margin-left:0px; padding-left:0px">
                         <div style="display:table; width:100%">
-                            <label for="ddlInjRate" style="text-align: center; display: block;">Units</label>
+                            <label for="ddlInjRate" style="text-align: center; display: block; margin-top: 8px;">Units</label>
                             <select class="form-control" asp-for="selInjectionRateUnitOption" asp-items="@(new SelectList(Model.injectionRateUnitOptions,"Id","Value"))" id="ddlInjRate"></select>
                             <span asp-validation-for="selInjectionRateUnitOption" class="text-danger"></span>
                         </div>
                     </div>
                     <div class="form-group col-sm-4">
-                        <label for="eventsPerSeason">Proposed Number of Fertigation Per Season</label>
+                        <label for="eventsPerSeason" style="margin-top: 8px;">Proposed Number of Fertigation Per Season</label>
                         <div>
                             <input class="form-control" id="eventsPerSeason" type="number" min="1" asp-for="eventsPerSeason" style="width:100px" />
                             <span asp-validation-for="eventsPerSeason" class="text-danger" value=1></span>
                         </div>
                     </div>
                     <div class="form-group col-sm-3">
-                        <label for="ddlMan">Fertigation Scheduling</label>
+                        <label for="ddlMan" style="margin-top: 8px;">Fertigation Scheduling</label>
                         <select class="form-control" id="ddlApplPeriod" style="width:100%" asp-for="selFertSchedOption" asp-items="@(new SelectList(Model.applPeriod,"Id","Value"))">
                             <option></option>
                         </select>
@@ -243,11 +249,14 @@
               <div class="row">
                 <div class="form-group">
                 @if(Model.selTypOption == "1" || Model.selTypOption == "2"){
-                    <div class="form-group col-sm-4" style="display:flex; align-items: center;">
+                    <div class="form-group col-sm-4" style="display:flex; align-items: center; margin-left: 30px;">
                       <div>
                           <label >
                               Fertigation Time (Minutes)
                           </label>
+                          <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
+                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                          </a>
                           <div class="cell" style="text-align:center">
                             @Model.fertigationTime
                           </div>
@@ -279,6 +288,9 @@
                           <label >
                               Fertigation Time (Minutes)
                           </label>
+                            <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
+                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                          </a>
                           <div class="cell" style="text-align:center">
                             @Model.fertigationTime
                           </div>
@@ -455,7 +467,35 @@
 </div>
 
 <script>
-   $(document).ready(function () {
+$(document).ready(function () {
+  //Tooltips for injectionRate rate
+    $('#toolTipExplainInjectionRate').tooltip({
+        template: toolTipClickableInnerHtml,
+        html: true,
+        trigger: 'manual',
+    });
+    $('#toolTipExplainInjectionRate').click(function () {
+        triggerToolTip($('#toolTipExplainInjectionRate'));
+    });
+    //tooltip for Application rate
+    $('#toolTipExplainApplicationRate').tooltip({
+        template: toolTipClickableInnerHtml,
+        html: true,
+        trigger: 'manual',
+    });
+    $('#toolTipExplainApplicationRate').click(function () {
+        triggerToolTip($('#toolTipExplainApplicationRate'));
+    });
+    //tooltip for times per fertigation
+    $('#toolTipExplainTime').tooltip({
+        template: toolTipClickableInnerHtml,
+        html: true,
+        trigger: 'manual',
+    });
+    $('#toolTipExplainTime').click(function () {
+        triggerToolTip($('#toolTipExplainTime'));
+    });
+
     $('#applDate').datepicker({
         format: "dd-M-yyyy", 
         autoclose: true,

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -24,21 +24,21 @@
                     </div>
                     <div class="form-group col-sm-3" style="width:200px; margin-top: 8px; height: 57.56px;">
                         @if(Model.selTypOption == "4" || Model.selTypOption == "2"){ // if custom liquid fertigation
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:50px; padding-left: 0px;">
                                 <label for="valN">N(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valN" id="valN" type="text" />
                                     <span asp-validation-for="valN" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:50px; padding-left: 0px;">
                                 <label for="valP2o5">P₂O₅(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valP2o5" id="valP2o5" type="text" />
                                     <span asp-validation-for="valP2o5" class="text-danger"></span>
                                 </div>
                             </div>
-                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:60px">
+                            <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:50px; padding-left: 0px;">
                                 <label for="valK2o">K₂O(%)</label>
                                 <div>
                                     <input class="form-control" asp-for="valK2o" id="valK2o" type="text" />
@@ -103,7 +103,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="form-group col-sm-4" style="display:flex; align-items: center; width: 100px; margin-top: 8px;">
+                    <div class="form-group col-sm-4" style="display:flex; align-items: center; width: 160px; margin-top: 8px;">
                       <div>
                           <label >
                               Solubility Assessment
@@ -153,7 +153,7 @@
                       </div>
                       </div>
                     } else {
-                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:120px">
+                        <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:150px">
                             <label for="rate">Application Rate</label>
                             <a href="#" data-toggle="tooltip" title="@Model.ExplainApplicationRate" id="toolTipExplainApplicationRate">
                                 <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Application Rate" style="font-size:20px;"></span>
@@ -253,11 +253,11 @@
                       <div>
                           <label style="display:flex; align-items:center; padding-left: 50px;">
                               Time per Application
+                              <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
+                                  <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                              </a>
                           </label>
-                          <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
-                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
-                          </a>
-                          <div class="cell" style="text-wrap: pretty; text-align: center;">
+                          <div class="cell" style="text-wrap: pretty; text-align: center; padding-left: 50px;">
                             @Model.fertigationTime minutes
                           </div>
                       </div>
@@ -285,12 +285,12 @@
                   </div>
                   <div class="form-group col-sm-8" style="margin:5px">
                       <div class="table">
-                          <label style="height: 40px; text-align:center">
+                          <label style="height: 40px; text-align:center; margin-left: 50px;">
                               Time per Application
+                              <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
+                                  <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                              </a>
                           </label>
-                            <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
-                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
-                          </a>
                           <div class="cell" style="text-align:center">
                             @Model.fertigationTime minutes
                           </div>
@@ -526,7 +526,7 @@ $(document).ready(function () {
     function updateUnits() {
         var userUnit = $('#ddlProdRate').find("option:selected").text();
         $('#productVolumeLabel').text('Total Product Volume per Application (' + userUnit + ')');
-        $('#productVolumeGrowingLabel').text('Total Product Volume Growing Season (' + userUnit + ')');
+        $('#productVolumeGrowingLabel').text('Total Product Volume for Growing Season (' + userUnit + ')');
     }
 
     // On page load, initialize unit label

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -55,8 +55,11 @@
 
                     </div>
                     @if(Model.selTypOption == "1" || Model.selTypOption == "2"){ 
-                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:100px; margin-top: 8px;">
+                    <div class="form-group col-sm-2" style="margin-right:0px; padding-right:0px; width:120px;">
                         <label for="rate">Tank Volume</label>
+                            <a href="#" data-toggle="tooltip" title="@Model.ExplainTime" id="toolTipExplainTime">
+                              <span class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Explanation of Time per Application" style="font-size:20px;"></span>
+                          </a>
                         <div>
                             <input class="form-control" asp-for="tankVolume" id="ddlTankVolume" type="text" />
                             <span asp-validation-for="tankVolume" class="text-danger"></span>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Add information Icon after 'Injection Rate' heading. When clicked, it should read: " Enter the rate in which your fertigation equipment applies fertilizer, not its overall output rate."
- Add information icon after 'Application Rate' (formerly Production Rate). When clicked, it should read: "The rate of fertilizer to be applied, not the overall output rate of your application system."
- Add information icon after 'Time Per Application' (formerly Fertigation Time). When clicked, it should read: "The amount of time required to apply fertilizer at the input fertilizer application rate, based on the injection rate entered above."
- Add information icon after 'Tank Volume' if Dry Fertilizer or Dry Fertilizer (Custom) is selected. When clicked, it should read: "".

![Screenshot 2024-12-10 at 4 17 07 PM](https://github.com/user-attachments/assets/986ba643-a81f-4826-9192-0f50ecd3f7af)
![Screenshot 2024-12-10 at 4 16 52 PM](https://github.com/user-attachments/assets/1096ecb3-399e-4f12-a764-6ae7162e91e1)
