### PR TITLE
fix(frontend)[NMP-706]: Calculation Fixes to Fertigation Modal

### DIFF
--- a/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
@@ -1016,9 +1016,10 @@ namespace SERVERAPI.Controllers
 
             fertArea = Convert.ToDecimal(fgvm.fieldArea);
 
-            fgvm.nutrientConcentrationN = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valN) / 100 / tankVolume, 2));
-            fgvm.nutrientConcentrationK2O = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valK2o) / 100 / tankVolume, 2));
-            fgvm.nutrientConcentrationP205 = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valP2o5) / 100 / tankVolume, 2));
+            //Need in lb/us gallon
+            fgvm.nutrientConcentrationN = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valN) / 100 / (tankVolume * 1.20095m), 2));
+            fgvm.nutrientConcentrationK2O = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valK2o) / 100 / (tankVolume * 1.20095m), 2));
+            fgvm.nutrientConcentrationP205 = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valP2o5) / 100 / (tankVolume * 1.20095m), 2));
 
             decimal injectionRate = Convert.ToDecimal(fgvm.injectionRate);
             fgvm.fertigationTime = Math.Round(Convert.ToDecimal(fgvm.tankVolume) / injectionRate, 0);

--- a/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
@@ -1023,7 +1023,7 @@ namespace SERVERAPI.Controllers
             decimal injectionRate = Convert.ToDecimal(fgvm.injectionRate);
             fgvm.fertigationTime = Math.Round(Convert.ToDecimal(fgvm.tankVolume) / injectionRate, 0);
 
-            if (amountToDissolve <= tankVolume * solInWater){
+            if (amountToDissolve <= tankVolume * solInWater/1000){
                 fgvm.dryAction = "Soluble";
             }
             else{


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
Amendments to calculations for fertigation modal as noted here [fertigation math](https://bcgov.sharepoint.com/:x:/r/teams/05196-NMP/Shared%20Documents/NMP/Fertigation%20math.xlsx?d=w6a784fb240b84b76aa6bcdd0db18ca3f&csf=1&web=1&e=MbWPRX)

This PR includes the following proposed change(s):

- Change to soluble calculation amountToDissolve <= tankVolume * solInWater/1000
- Change to nutrient concentration calculation (tankVolume * 1.20095m)

Time is correct when at more decimal places but other ticket we had the ui fixes to round time to nearest minute
![Screenshot 2024-12-19 at 1 25 43 PM](https://github.com/user-attachments/assets/51ba85b2-7142-478d-922c-c829cc6b6f1b)

![Screenshot 2024-12-19 at 1 07 26 PM](https://github.com/user-attachments/assets/0a7bc852-c0d2-4c04-bc62-73a1efd74a0d)