### PR TITLE
Fix[NMP-707]: UI Nutrient Concentration Units

### DIFF
--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -129,7 +129,7 @@
                     <div class="form-group col-sm-4" style="display:flex; align-items: center;">
                     <div class="Table">
                         <div class="Title">
-                            <p>Nutrient Concentration In Stock Solution(lb/gal)</p>
+                            <p>Nutrient Concentration In Stock Solution(lb/US gallon)</p>
                         </div>
                         <div class="Heading">
                             <div class="Cell">


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Changed Nutrient Concentration in Stock Solution from lb/imperial gallon to lb/US gallon.
![Screenshot 2024-12-23 at 11 17 20 AM](https://github.com/user-attachments/assets/2246e301-8509-4291-970b-9083a8bbde01)

