### PR TITLE
Fix[NMP-708]: Fertigation Time Fix

### DIFF
--- a/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
+++ b/app/Server/src/SERVERAPI/Controllers/NutrientsController.cs
@@ -990,6 +990,7 @@ namespace SERVERAPI.Controllers
             decimal tankVolume;
             decimal solInWater;
             decimal fertArea;
+            decimal convertedInjectionRate = 1;
 
             if (fgvm.amountToDissolveUnits != "1"){
                 decimal convertedAmount = ConvertDissolve(Convert.ToDecimal(fgvm.amountToDissolve), (DissolveUnit)Convert.ToInt32(fgvm.amountToDissolveUnits), DissolveUnit.Pounds);
@@ -1014,6 +1015,20 @@ namespace SERVERAPI.Controllers
                 solInWater = Convert.ToDecimal(fgvm.solInWater);
             }
 
+            // used to calculate fertigation time
+            switch (fgvm.selInjectionRateUnitOption)
+            {
+                case "1": // US gallon/min to Imperial Gallon/min
+                    convertedInjectionRate = Convert.ToDecimal(fgvm.injectionRate) / 1.20095M;
+                    break;
+                case "2": // L/min to Imperial Gallon/min
+                    convertedInjectionRate = Convert.ToDecimal(fgvm.injectionRate) / 4.54609M;
+                    break;
+                case "3": // Imperial Gallon/min
+                    convertedInjectionRate = Convert.ToDecimal(fgvm.injectionRate);
+                    break;
+            }
+
             fertArea = Convert.ToDecimal(fgvm.fieldArea);
 
             //Need in lb/us gallon
@@ -1021,8 +1036,9 @@ namespace SERVERAPI.Controllers
             fgvm.nutrientConcentrationK2O = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valK2o) / 100 / (tankVolume * 1.20095m), 2));
             fgvm.nutrientConcentrationP205 = Convert.ToString(Math.Round(amountToDissolve * Convert.ToDecimal(fgvm.valP2o5) / 100 / (tankVolume * 1.20095m), 2));
 
-            decimal injectionRate = Convert.ToDecimal(fgvm.injectionRate);
-            fgvm.fertigationTime = Math.Round(Convert.ToDecimal(fgvm.tankVolume) / injectionRate, 0);
+
+            fgvm.fertigationTime = Math.Round(tankVolume / convertedInjectionRate, 0);
+
 
             if (amountToDissolve <= tankVolume * solInWater/1000){
                 fgvm.dryAction = "Soluble";


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- When tank volume unit was changed and converted the application time was also changing. Added conversion for injection rate and updated fertigation time calculation. Time is now stable even when units are changed and converted.
- Double checked calculations all product details calculations and conversions to ensure they matched the [provided spreadsheet.](https://bcgov.sharepoint.com/:x:/r/teams/05196-NMP/Shared%20Documents/NMP/Fertigation%20Calculator%20UX/Fertigation%20math.xlsx?d=w6a784fb240b84b76aa6bcdd0db18ca3f&csf=1&web=1&e=W5foJV)
![Screenshot 2024-12-23 at 4 06 25 PM](https://github.com/user-attachments/assets/95688382-381d-4204-9a95-6c1c1392a696)
![Screenshot 2024-12-23 at 4 06 33 PM](https://github.com/user-attachments/assets/015e02d0-93c3-40d0-ab7e-53334bdb6e13)
![Screenshot 2024-12-23 at 4 06 41 PM](https://github.com/user-attachments/assets/9aadd547-e236-4833-bd91-810ed57ab8ac)
