### PR TITLE
Fix[AGRI-NMP-709]: Missing Calculated Nutrients when Editing

### DIFF
--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -548,5 +548,20 @@ $(document).ready(function () {
 
     // On page load, initialize unit label
     updateUnits();
+
+    function editCalculate() {
+      //to alculate Nutrients when editing
+        var modelTitle = $('#myModalLabel').text().toLowerCase();
+        if (modelTitle.includes("edit")) {
+            setTimeout(function () {
+                $('#calc_button').click();
+            }, 500);  // 500ms delay to ensure the modal is fully rendered
+        }
+    }
+
+    $('#myModal').on('show.bs.modal', function () {
+        editCalculate();  // Call the function when the modal opens
+    });
+
 });
 </script>

--- a/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
+++ b/app/Server/src/SERVERAPI/Views/Nutrients/FertigationDetails.cshtml
@@ -550,17 +550,17 @@ $(document).ready(function () {
     updateUnits();
 
     function editCalculate() {
-      //to alculate Nutrients when editing
+      //to calculate Nutrients when editing
         var modelTitle = $('#myModalLabel').text().toLowerCase();
         if (modelTitle.includes("edit")) {
             setTimeout(function () {
                 $('#calc_button').click();
-            }, 500);  // 500ms delay to ensure the modal is fully rendered
+            }, 1000);
         }
     }
 
     $('#myModal').on('show.bs.modal', function () {
-        editCalculate();  // Call the function when the modal opens
+        editCalculate();
     });
 
 });


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- change so calculate button is triggered when edit modal opened
- ![Screenshot 2025-01-03 at 3 44 05 PM](https://github.com/user-attachments/assets/39ac38fa-1701-46fa-9de5-ee7ac5061a44)

(Ticket [718](https://github.com/bcgov/agri-nmp/issues/718) created to address bug related to editing dry fertigation)
